### PR TITLE
SQ2-1050 - better error handling, DRY Faraday plumbing

### DIFF
--- a/lib/kira.rb
+++ b/lib/kira.rb
@@ -8,5 +8,6 @@ module Kira
 end
 
 require 'kira/errors'
+require 'kira/v2/client'
 require 'kira/v2/applicant'
 require 'kira/v2/interview'

--- a/lib/kira/errors.rb
+++ b/lib/kira/errors.rb
@@ -1,8 +1,28 @@
 module Kira
-  class Error < RuntimeError; end
+  class Error < RuntimeError
+    attr_reader :status, :body, :parsed
+
+    def initialize(message = nil, status: nil, body: nil, parsed: nil)
+      @status = status
+      @body   = body
+      @parsed = parsed
+      super(message || _default_message)
+    end
+
+    private
+
+    def _default_message
+      if @parsed.is_a?(Hash) && @parsed["detail"]
+        @parsed["detail"]
+      elsif @body && !@body.empty?
+        "Kira API error #{@status}: #{@body[0, 200]}"
+      else
+        "Kira API error #{@status}"
+      end
+    end
+  end
 
   module ApplicantError
     class Exists < Kira::Error; end
   end
-
 end

--- a/lib/kira/v2/applicant.rb
+++ b/lib/kira/v2/applicant.rb
@@ -1,7 +1,6 @@
 class Kira::V2::Applicant
   include Contracts
-
-  BASE_URL = 'https://app.kiratalent.com/api'
+  include Kira::V2::Client
 
   Contract String, String => Any
   def initialize(interview_id, token)
@@ -10,29 +9,6 @@ class Kira::V2::Applicant
 
   Contract Hash => Hash
   def create(applicant)
-
-    url = "#{BASE_URL}/interviews/#{@interview_id}/applicants/"
-
-    res = conn.post do |req|
-      req.url url
-      req.headers["Authorization"] = " Token #{@token}"
-      req.headers["Accept"] = "application/vnd.kiratalent.v2+json"
-      req.headers["Content-Type"] = "application/json"
-      req.body = applicant.to_json
-    end
-
-    response = JSON.parse(res.body)
-    res.success? ? response : handle_error(response)
+    request(:post, "/interviews/#{@interview_id}/applicants/", body: applicant)
   end
-
-  private
-
-    def conn
-      @conn ||= Faraday.new(BASE_URL)
-    end
-
-    def handle_error(response)
-      raise Kira::Error.new(response)
-    end
-
 end

--- a/lib/kira/v2/client.rb
+++ b/lib/kira/v2/client.rb
@@ -21,7 +21,7 @@ module Kira
       end
 
       def request(method, path, body: nil)
-        res = conn.send(method) do |req|
+        res = conn.public_send(method) do |req|
           req.url "#{BASE_URL}#{path}"
           req.headers.update(auth_headers)
           req.body = body.to_json if body

--- a/lib/kira/v2/client.rb
+++ b/lib/kira/v2/client.rb
@@ -1,0 +1,58 @@
+module Kira
+  module V2
+    # Shared HTTP plumbing for the v2 API: Faraday connection, auth headers,
+    # request dispatch, and response/error mapping. Mix in via `include Kira::V2::Client`
+    # and set `@token` in the host class's initializer.
+    module Client
+      BASE_URL = 'https://app.kiratalent.com/api'.freeze
+
+      private
+
+      def conn
+        @conn ||= Faraday.new(BASE_URL)
+      end
+
+      def auth_headers
+        {
+          "Authorization" => "Token #{@token}",
+          "Accept"        => "application/vnd.kiratalent.v2+json",
+          "Content-Type"  => "application/json"
+        }
+      end
+
+      def request(method, path, body: nil)
+        res = conn.send(method) do |req|
+          req.url "#{BASE_URL}#{path}"
+          req.headers.update(auth_headers)
+          req.body = body.to_json if body
+        end
+
+        handle_response(res)
+      end
+
+      def handle_response(res)
+        parsed = safe_json_parse(res.body)
+        return parsed if res.success?
+
+        raise _build_error(res, parsed)
+      end
+
+      def safe_json_parse(body)
+        JSON.parse(body)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def _build_error(res, parsed)
+        klass = _applicant_already_exists?(res, parsed) ? Kira::ApplicantError::Exists : Kira::Error
+        klass.new(status: res.status, body: res.body, parsed: parsed)
+      end
+
+      def _applicant_already_exists?(res, parsed)
+        res.status == 409 &&
+          parsed.is_a?(Hash) &&
+          parsed["detail"].to_s.include?("already been registered")
+      end
+    end
+  end
+end

--- a/lib/kira/v2/interview.rb
+++ b/lib/kira/v2/interview.rb
@@ -1,7 +1,6 @@
 class Kira::V2::Interview
   include Contracts
-
-  BASE_URL = 'https://app.kiratalent.com/api'
+  include Kira::V2::Client
 
   Contract String, String, String => Any
   def initialize(interview_id, token, secret)
@@ -14,50 +13,16 @@ class Kira::V2::Interview
     active: Optional[Bool]
   ] => Or[Hash, Bool]
   def create(endpoint:, event_subscriptions:, active: true)
-    url = "#{BASE_URL}/interviews/#{@interview_id}/webhooks/"
+    path = "/interviews/#{@interview_id}/webhooks/"
 
-    # check first if a webhook for this interview already exists
-    res = conn.get do |req|
-      req.url url
-      req.headers["Authorization"] = " Token #{@token}"
-      req.headers["Accept"] = "application/vnd.kiratalent.v2+json"
-      req.headers["Content-Type"] = "application/json"
-    end
+    existing = request(:get, path)
+    return true if existing.any? { |webhook| webhook['event_subscriptions'].include?('applicant.interview_completed') }
 
-    response = JSON.parse(res.body)
-    handle_error(response) unless res.success?
-
-    # return if a webhook already exists
-    return true if response.any? { |webhook| webhook['event_subscriptions'].include?('applicant.interview_completed') }
-
-    # create a webhook otherwise
-    request_body = {
-      "endpoint": endpoint,
-      "event_subscriptions": event_subscriptions,
-      "active": active,
-      "secret": @secret
-    }
-
-    res = conn.post do |req|
-      req.url url
-      req.headers["Authorization"] = " Token #{@token}"
-      req.headers["Accept"] = "application/vnd.kiratalent.v2+json"
-      req.headers["Content-Type"] = "application/json"
-      req.body = request_body.to_json
-    end
-
-    response = JSON.parse(res.body)
-    res.success? ? response : handle_error(response)
+    request(:post, path, body: {
+      endpoint: endpoint,
+      event_subscriptions: event_subscriptions,
+      active: active,
+      secret: @secret
+    })
   end
-
-  private
-
-    def conn
-      @conn ||= Faraday.new(BASE_URL)
-    end
-
-    def handle_error(response)
-      raise Kira::Error.new(response)
-    end
-
 end

--- a/spec/lib/kira/v2/applicant_spec.rb
+++ b/spec/lib/kira/v2/applicant_spec.rb
@@ -71,9 +71,13 @@ describe Kira::V2::Applicant do
         }
       end
 
-      it "raises Kira::Error when posting the same applicant twice" do
+      it "raises Kira::ApplicantError::Exists on the second create" do
         service.create(applicant_params)
-        expect { service.create(applicant_params) }.to raise_error(Kira::Error)
+
+        expect { service.create(applicant_params) }.to raise_error(Kira::ApplicantError::Exists) { |e|
+          expect(e.status).to eq(409)
+          expect(e.parsed["detail"]).to include("already been registered")
+        }
       end
     end
 
@@ -86,12 +90,14 @@ describe Kira::V2::Applicant do
         }
       end
 
-      it "raises Kira::Error" do
-        expect { service.create(applicant_params) }.to raise_error(Kira::Error)
+      it "raises Kira::Error with the HTTP status and parsed body" do
+        expect { service.create(applicant_params) }.to raise_error(Kira::Error) { |e|
+          expect(e.status).to eq(400)
+          expect(e.parsed).to be_a(Hash)
+        }
       end
     end
 
-    # XXX: SQ2-1050 will wrap this in a Kira::Error carrying the HTTP status.
     # Cassette is hand-crafted (Kira won't return 5xx for us on demand) and
     # pinned with `record: :none` so it can't be accidentally re-recorded.
     context "when Kira returns a 5xx without a JSON body",
@@ -100,8 +106,12 @@ describe Kira::V2::Applicant do
         { first_name: "Peter", last_name: "Pan", email: "peter@example.com" }
       end
 
-      it "leaks JSON::ParserError" do
-        expect { service.create(applicant_params) }.to raise_error(JSON::ParserError)
+      it "raises Kira::Error carrying the HTTP status and raw body" do
+        expect { service.create(applicant_params) }.to raise_error(Kira::Error) { |e|
+          expect(e.status).to eq(500)
+          expect(e.body).to include("Internal Server Error")
+          expect(e.parsed).to be_nil
+        }
       end
     end
 

--- a/spec/lib/kira/v2/interview_spec.rb
+++ b/spec/lib/kira/v2/interview_spec.rb
@@ -63,22 +63,27 @@ describe Kira::V2::Interview do
             vcr: { cassette_name: "interview/get_unauthorized" } do
       let(:token) { "definitely-not-a-real-token" }
 
-      it "raises Kira::Error" do
+      it "raises Kira::Error carrying the HTTP status" do
         expect {
           service.create(endpoint: endpoint, event_subscriptions: event_subscriptions)
-        }.to raise_error(Kira::Error)
+        }.to raise_error(Kira::Error) { |e|
+          expect(e.status).to eq(401)
+        }
       end
     end
 
-    # XXX: SQ2-1050 will wrap this in a Kira::Error carrying the HTTP status.
     # Cassette is hand-crafted (Kira won't return 5xx for us on demand) and
     # pinned with `record: :none` so it can't be accidentally re-recorded.
     context "when Kira returns a 5xx without a JSON body",
             vcr: { cassette_name: "interview/server_error_html", record: :none } do
-      it "leaks JSON::ParserError" do
+      it "raises Kira::Error carrying the HTTP status and raw body" do
         expect {
           service.create(endpoint: endpoint, event_subscriptions: event_subscriptions)
-        }.to raise_error(JSON::ParserError)
+        }.to raise_error(Kira::Error) { |e|
+          expect(e.status).to eq(500)
+          expect(e.body).to include("Internal Server Error")
+          expect(e.parsed).to be_nil
+        }
       end
     end
 


### PR DESCRIPTION
**Stacked on #10 (SQ2-1048).**

* Extracts common request/Faraday code to `Kira::V2::Client`
* Improves error handling
  * `Kira::Error` now includes status, body, and parsed body
  * _Attempts_ to parse the body as JSON instead of failing hard on a 500 status from the server
  * `Kira::ApplicantError::Exists` actually works now