### PR TITLE
SQ2-1052 - feat: allow overriding BASE_URL via constructor kwarg

### DIFF
--- a/lib/kira/v2/applicant.rb
+++ b/lib/kira/v2/applicant.rb
@@ -2,9 +2,9 @@ class Kira::V2::Applicant
   include Contracts
   include Kira::V2::Client
 
-  Contract String, String => Any
-  def initialize(interview_id, token)
-    @interview_id, @token = interview_id, token
+  Contract String, String, KeywordArgs[base_url: Optional[String]] => Any
+  def initialize(interview_id, token, base_url: nil)
+    @interview_id, @token, @base_url = interview_id, token, base_url
   end
 
   Contract Hash => Hash

--- a/lib/kira/v2/client.rb
+++ b/lib/kira/v2/client.rb
@@ -2,14 +2,18 @@ module Kira
   module V2
     # Shared HTTP plumbing for the v2 API: Faraday connection, auth headers,
     # request dispatch, and response/error mapping. Mix in via `include Kira::V2::Client`
-    # and set `@token` in the host class's initializer.
+    # and set `@token` (and optionally `@base_url`) in the host class's initializer.
     module Client
       BASE_URL = 'https://app.kiratalent.com/api'.freeze
 
       private
 
+      def base_url
+        @base_url || BASE_URL
+      end
+
       def conn
-        @conn ||= Faraday.new(BASE_URL)
+        @conn ||= Faraday.new(base_url)
       end
 
       def auth_headers
@@ -22,7 +26,7 @@ module Kira
 
       def request(method, path, body: nil)
         res = conn.public_send(method) do |req|
-          req.url "#{BASE_URL}#{path}"
+          req.url "#{base_url}#{path}"
           req.headers.update(auth_headers)
           req.body = body.to_json if body
         end

--- a/lib/kira/v2/interview.rb
+++ b/lib/kira/v2/interview.rb
@@ -2,9 +2,9 @@ class Kira::V2::Interview
   include Contracts
   include Kira::V2::Client
 
-  Contract String, String, String => Any
-  def initialize(interview_id, token, secret)
-    @interview_id, @token, @secret = interview_id, token, secret
+  Contract String, String, String, KeywordArgs[base_url: Optional[String]] => Any
+  def initialize(interview_id, token, secret, base_url: nil)
+    @interview_id, @token, @secret, @base_url = interview_id, token, secret, base_url
   end
 
   Contract KeywordArgs[

--- a/spec/lib/kira/v2/applicant_spec.rb
+++ b/spec/lib/kira/v2/applicant_spec.rb
@@ -127,5 +127,22 @@ describe Kira::V2::Applicant do
         expect { service.create(applicant_params) }.to raise_error(Faraday::Error)
       end
     end
+
+    context "with a custom base_url override" do
+      let(:custom_base_url) { "https://staging.example.com/api" }
+      let(:service) { Kira::V2::Applicant.new(interview_id, token, base_url: custom_base_url) }
+      let(:applicant_params) do
+        { first_name: "Peter", last_name: "Pan", email: "peter@example.com" }
+      end
+
+      it "routes the request to the custom host" do
+        stub = stub_request(:post, "#{custom_base_url}/interviews/#{interview_id}/applicants/")
+                 .to_return(status: 201, body: "{}", headers: { "Content-Type" => "application/json" })
+
+        service.create(applicant_params)
+
+        expect(stub).to have_been_requested
+      end
+    end
   end
 end

--- a/spec/lib/kira/v2/interview_spec.rb
+++ b/spec/lib/kira/v2/interview_spec.rb
@@ -97,5 +97,23 @@ describe Kira::V2::Interview do
         }.to raise_error(Faraday::Error)
       end
     end
+
+    context "with a custom base_url override" do
+      let(:custom_base_url) { "https://staging.example.com/api" }
+      let(:service) { Kira::V2::Interview.new(interview_id, token, secret, base_url: custom_base_url) }
+
+      it "routes the existing-webhook GET to the custom host" do
+        stub = stub_request(:get, "#{custom_base_url}/interviews/#{interview_id}/webhooks/")
+                 .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+        # Stub the follow-up POST too so the example finishes cleanly.
+        stub_request(:post, "#{custom_base_url}/interviews/#{interview_id}/webhooks/")
+          .to_return(status: 201, body: "{}", headers: { "Content-Type" => "application/json" })
+
+        service.create(endpoint: endpoint, event_subscriptions: event_subscriptions)
+
+        expect(stub).to have_been_requested
+      end
+    end
   end
 end


### PR DESCRIPTION
**Stacked on #11 (SQ2-1050), which is stacked on #10 (SQ2-1048).**

Accepts `base_url` as a constructor param for easier test server stubbing.