### PR TITLE
SQ2-1098 - tolerate non-409 duplicate-registration responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.1 — 2026-05-26
+
+### Fixed
+
+- `Kira::ApplicantError::Exists` was only raised when Kira returned `409` with a `{"detail": "..."}` Hash body. Kira's API has been observed returning the same condition as `400` with a bare JSON string body (`"This email address has already been registered to <uid>."`), and possibly other shapes — neither passed the old classifier, so the duplicate-registration recovery path silently broke. The check is now keyed off the message wording across status codes and body shapes.
+
 ## 3.1.0 — 2026-05-25
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kira-client (3.1.0)
+    kira-client (3.1.1)
       contracts
       faraday (~> 2.13)
 
@@ -27,7 +27,6 @@ GEM
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     ffi (1.17.4)
-    ffi (1.17.4-arm64-darwin)
     formatador (1.2.3)
       reline
     guard (2.20.1)

--- a/kira-client.gemspec
+++ b/kira-client.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = "kira-client"
-  s.version     = "3.1.0"
-  s.date        = "2026-05-25"
+  s.version     = "3.1.1"
+  s.date        = "2026-05-26"
   s.summary     = "Kira Client"
   s.description = "Client to interact with the Kira API"
   s.authors     = ["Luis Correa d'Almeida"]

--- a/lib/kira/v2/client.rb
+++ b/lib/kira/v2/client.rb
@@ -61,9 +61,19 @@ class Kira::V2::Client
     klass.new(status: res.status, body: res.body, parsed: parsed)
   end
 
-  def _applicant_already_exists?(res, parsed)
-    res.status == 409 &&
-      parsed.is_a?(Hash) &&
-      parsed["detail"].to_s.include?("already been registered")
+  # Kira signals "this email is already registered against the interview" with
+  # a few different response shapes — historically 409 with `{"detail": "..."}`,
+  # currently 400 with a bare JSON string. The wording of the message is the
+  # stable bit; key off that regardless of status or body shape.
+  ALREADY_REGISTERED_RE = /already been registered/.freeze
+
+  def _applicant_already_exists?(_res, parsed)
+    detail = case parsed
+             when Hash   then parsed["detail"].to_s
+             when String then parsed
+             else            ""
+             end
+
+    ALREADY_REGISTERED_RE.match?(detail)
   end
 end

--- a/spec/cassettes/applicant/create_duplicate_400_string.yml
+++ b/spec/cassettes/applicant/create_duplicate_400_string.yml
@@ -1,0 +1,31 @@
+---
+# Hand-crafted from a real Kira response (observed 2026-05-26). The duplicate-
+# registration error now comes back as 400 with a bare JSON string body instead
+# of the older 409 + {"detail": "..."} shape. Pinned to record: :none.
+http_interactions:
+- request:
+    method: post
+    uri: https://app.kiratalent.com/api/interviews/fqvjnY/applicants/
+    body:
+      encoding: UTF-8
+      string: '{"first_name":"Peter","last_name":"Pan","email":"peter@example.com"}'
+    headers:
+      Authorization:
+      - Token <KIRA_TOKEN>
+      Accept:
+      - application/vnd.kiratalent.v2+json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/vnd.kiratalent.v2+json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '"This email address has already been registered to tF21eW."'
+    http_version: '1.1'
+  recorded_at: Tue, 26 May 2026 09:52:16 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/kira/v2/applicants_spec.rb
+++ b/spec/lib/kira/v2/applicants_spec.rb
@@ -71,6 +71,22 @@ describe Kira::V2::Applicants do
       end
     end
 
+    # Kira's API has been observed returning the duplicate-registration error
+    # as 400 with a bare JSON string body (instead of 409 + Hash). Pinned to
+    # record: :none so the cassette stays stable.
+    context "when Kira returns the duplicate error as 400 + bare string",
+            vcr: { cassette_name: "applicant/create_duplicate_400_string", record: :none } do
+      it "still raises Kira::ApplicantError::Exists" do
+        expect {
+          applicants.create(first_name: "Peter", last_name: "Pan", email: "peter@example.com")
+        }.to raise_error(Kira::ApplicantError::Exists) { |e|
+          expect(e.status).to eq(400)
+          expect(e.parsed).to be_a(String)
+          expect(e.parsed).to include("already been registered")
+        }
+      end
+    end
+
     context "when the email is invalid", vcr: { cassette_name: "applicant/create_invalid_email" } do
       it "raises Kira::Error with the HTTP status and parsed body" do
         expect {


### PR DESCRIPTION
Kira will sometimes return a JSON object and others a bare string when the email is double-registered in an interview.